### PR TITLE
updated response.status test for PATCH

### DIFF
--- a/spec/controllers/reservations_controller_spec.rb
+++ b/spec/controllers/reservations_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe ReservationsController, :type => :controller do
   describe 'PATCH /reservations/:id.json' do 
     it 'updates an existing reservation' do 
       patch :update, format: :json, id: 1, :reservation => {checkin: '2014-09-05', checkout: '2014-10-01', guest_id: 5, listing_id: 2}
-      expect(response.status).to eq 200
+      expect(response).to be_ok
       expect(Reservation.first.checkin).to eq(Date.parse('2014-09-05'))
     end
 


### PR DESCRIPTION
format.json { head :no_content } in the update method in the Reservation controller now sends a 204 status and not a 200.  The student can research to discover that this should be changed to { head :ok } or { head 200 } (like I did), but that doesn't seem to be the point of the lab. Since Rails default changed from 200 to 204, you can simply make the test slightly more generic by testing for the status to be ok.
